### PR TITLE
Implement tonumber/0 builtin

### DIFF
--- a/packages/jq/src/lib/evaluate/filters/builtinNativeFilters.ts
+++ b/packages/jq/src/lib/evaluate/filters/builtinNativeFilters.ts
@@ -435,8 +435,31 @@ export const builtinNativeFilters: Record<string, NativeFilter> = {
     *'tojson/0'() {
       throw notImplementedError('tojson/0');
     },
-    *'tonumber/0'() {
-      throw notImplementedError('tonumber/0');
+    *'tonumber/0'(input: unknown) {
+      const type = typeOf(input);
+      switch (typeOf(input)) {
+        case Type.string: {
+          const parsedNumber = Number(input);
+          if(isNaN(parsedNumber)) {
+            throw Error(`${type} (${toString(input)}) cannot be parsed as number`);
+          }
+          if(!isFinite(parsedNumber)) {
+            yield parsedNumber > 0 ? Number.MAX_VALUE : -1 * Number.MAX_VALUE;
+            break;
+          }
+          yield parsedNumber;
+        break;
+        }
+        case Type.number:
+          yield input;
+          break;
+        case Type.object:
+        case Type.array:
+        case Type.null:
+        case Type.boolean:
+        default:
+          throw Error(`${type} (${toString(input)}) cannot be parsed as number`);
+      }
     },
     *'tostring/0'(input: unknown) {
       yield toString(input);

--- a/packages/jq/src/lib/evaluate/filters/builtinNativeFilters.ts
+++ b/packages/jq/src/lib/evaluate/filters/builtinNativeFilters.ts
@@ -437,7 +437,7 @@ export const builtinNativeFilters: Record<string, NativeFilter> = {
     },
     *'tonumber/0'(input: unknown) {
       const type = typeOf(input);
-      switch (typeOf(input)) {
+      switch (type) {
         case Type.string: {
           const parsedNumber = Number(input);
           if(isNaN(parsedNumber)) {

--- a/packages/jq/src/lib/evaluate/spec/builtins.spec.ts
+++ b/packages/jq/src/lib/evaluate/spec/builtins.spec.ts
@@ -909,11 +909,29 @@ describe('builtins', () => {
     //     throw notImplementedError('tojson/0');
     //   });
     // });
-    // describe('tonumber/0', () => {
-    //   it('tonumber/0', () => {
-    //     throw notImplementedError('tonumber/0');
-    //   });
-    // });
+    describe('tonumber/0', () => {
+      it('null', () => {
+        expectCodeError('null | tonumber');
+      });
+      it('boolean', () => {
+        expectCodeError('false | tonumber');
+        expectCodeError('true | tonumber');
+      });
+      it('numeric string', () => {
+        expectCode('"123", "0.123", "0" | tonumber', [123, 0.123, 0]);
+        expectCode('"Infinity", "-Infinity" | tonumber', [1.7976931348623157e+308, -1.7976931348623157e+308]);
+      });
+      it('non-numeric string', () => {
+        expectCodeError('"10a" | tonumber');
+        expectCodeError('"test" | tonumber');
+      });
+      it('array', () => {
+        expectCodeError('[1, 2, 3], [] | tonumber');
+      });
+      it('object', () => {
+        expectCodeError('{a:"a","1":1}, {} | tonumber');
+      });
+    });
     describe('tostring/0', () => {
       it('null', () => {
         expectCode('null | tostring', ['null']);


### PR DESCRIPTION
`tonumber/0` builtin filter implementation

Behaviour is exactly the same like `jq`.
* `bool`, `array`, `object`, and non-numeric `string` throws error
* `number` and numeric `string` returns parsed number
* returns max possible value for `"Infinity"` and `"-Infinity"` (`Number.MAX_VALUE = 1.7976931348623157e+308`)